### PR TITLE
fix regenie additive test not working with --test

### DIFF
--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -4,6 +4,8 @@ task step2 {
     File cov_pheno
     String covariates
     String test
+    # regenie accepts either no test specified (i.e. additive), or '--test dominant' or '--test recessive'. '--test additive' is an error.
+    String test_cmd = if test == "additive" then "" else "--test "+ test
     Boolean is_binary
     File bgen
     File bgi = bgen + ".bgi"
@@ -27,7 +29,7 @@ task step2 {
 
         regenie \
         --step 2 \
-        --test ${test} \
+        ${test_cmd} \
         ${if is_binary then "--bt --af-cc" else ""} \
         --bgen ${bgen} \
         --ref-first \


### PR DESCRIPTION
Latest regenie wdl introduced the "regenie_sub.step_2.test" parameter, which was plugged into regenie's "--test" parameter. However, regenie's makers in their great wisdom made it so that regenie has three test types: 
1. additive, which is invoked by not including the "--test" parameter (i.e. it is the default)
2. dominant, invoked with "--test dominant"
3. recessive, invoked with "--test recessive"
Using "--test additive" causes regenie to fail. This was the wdl behaviour.
This removes the use of "--test additive" in the wdl, and if additive is used as the test type, omits the "--test" parameter. Otherwise, the test parameter is used (for additive and dominant analyses). 