### PR TITLE
Update regenie version + Add firth null recycling

### DIFF
--- a/wdl/gwas/regenie.json
+++ b/wdl/gwas/regenie.json
@@ -1,6 +1,6 @@
 {
-    "regenie.sub_step1.step1.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.0.2.gz.afcc",
-    "regenie.sub_step2.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.0.2.gz.afcc",
+    "regenie.sub_step1.step1.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.2.4.fixed.gz.mkl",
+    "regenie.sub_step2.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.2.4.fixed.gz.mkl",
 
     "regenie.phenolist": "gs://path/to/phenolist",
     "regenie.is_binary": true,

--- a/wdl/gwas/regenie.wdl
+++ b/wdl/gwas/regenie.wdl
@@ -14,7 +14,7 @@ workflow regenie {
             input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates
         }
         call sub.regenie_step2 as sub_step2 {
-            input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates, pred=sub_step1.pred, loco=sub_step1.loco
+            input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates, pred=sub_step1.pred, loco=sub_step1.loco, nulls=sub_step1.nulls, firth_list=sub_step1.firth_list
         }
     }
 }

--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -36,6 +36,7 @@ task step1 {
         --gz \
         --threads $n_cpu \
         --out ${prefix} \
+        --write-null-firth
         ${options}
 
         # rename loco files with phenotype names and update pred.list accordingly giving it a unique name
@@ -43,12 +44,19 @@ task step1 {
         phenohash=`echo ${sep="," phenolist} | md5sum | awk '{print $1}'`
         awk '{sub(/_[0-9]+.loco.gz/, "."$1".loco.gz", $2)} 1' ${prefix}_pred.list > ${prefix}.$phenohash.pred.list
 
+        # rename firth files with phenotype names and update firth.list accordingly giving it a unique name
+        awk '{orig=$2; sub(/_[0-9]+.firth.gz/, "."$1".firth.gz", $2); print "mv "orig" "$2} ' ${prefix}_firth.list | bash
+        phenohash=`echo ${sep="," phenolist} | md5sum | awk '{print $1}'`
+        awk '{sub(/_[0-9]+.firth.gz/, "."$1".firth.gz", $2)} 1' ${prefix}_firth.list > ${prefix}.$phenohash.firth.list
+
     >>>
 
     output {
         File log = prefix + ".log"
         Array[File] loco = glob("*.loco.gz")
         File pred = glob("*.pred.list")[0]
+        Array[File] nulls = glob("*.firth.gz")
+        File firth_list = glob("*.firth.list")[0]
     }
 
     runtime {
@@ -77,5 +85,7 @@ workflow regenie_step1 {
     output {
         File pred = step1.pred
         Array[File] loco = step1.loco
+        File firth_list = step1.firth_list
+        Array[File] nulls = step1.nulls
     }
 }

--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -63,7 +63,7 @@ task step1 {
 
         docker: "${docker}"
         cpu: if length(phenolist) == 1 then 1 else if length(phenolist) <=10 then 2 else 4
-        memory: if length(phenolist) == 1 then "6 GB" else "8 GB"
+        memory: if length(phenolist) == 1 then "8 GB" else "10 GB"
         disks: "local-disk 200 HDD"
         zones: "europe-west1-b europe-west1-c europe-west1-d"
         preemptible: 2

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -11,8 +11,10 @@ task step2 {
     File bgi = bgen + ".bgi"
     File sample = bgen + ".sample"
     File pred
+    File firth_list
     String prefix = sub(basename(pred), "_pred.list", "") + "." + basename(bgen)
     Array[File] loco
+    Array[File] nulls
     Int bsize
     String options
 
@@ -24,6 +26,11 @@ task step2 {
 
         # move loco files to /cromwell_root as pred file paths point there
         for file in ${sep=" " loco}; do
+            mv $file .
+        done
+
+        # move null files to /cromwell_root as firth_list file paths point there
+        for file in ${sep=" " nulls}; do
             mv $file .
         done
 
@@ -39,6 +46,7 @@ task step2 {
         --phenoFile ${cov_pheno} \
         --phenoColList ${sep="," phenolist} \
         --pred ${pred} \
+        --use-null-firth ${firth_list} \
         --bsize ${bsize} \
         --threads $n_cpu \
         --gz \
@@ -290,13 +298,15 @@ workflow regenie_step2 {
 
     String pred
     Array[String] loco
+    String firth_list
+    Array[String] nulls
 
     File bgenlist
     Array[String] bgens = read_lines(bgenlist)
 
     scatter (bgen in bgens) {
         call step2 {
-            input: docker=docker, phenolist=phenolist, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates, pred=pred, loco=loco, bgen=bgen
+            input: docker=docker, phenolist=phenolist, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates, pred=pred, loco=loco, nulls=nulls,firth_list=firth_list,bgen=bgen
         }
     }
 


### PR DESCRIPTION
- Update regenie version to 2.2.4, bringing up to 50% time savings in step 2
- Use firth null recycling in the wdl, so that we can recycle it from  step 1 to step 2.