### PR TITLE
Modify the workflow to allow quantitative traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This in an example scenario creating new phenotypes with R7 data and running tho
 9. Logs and results go under  
 `gs://fg-cromwell_fresh/regenie/WORKFLOW_ID`  
 Summary stats and tabix indexes:  
-`gs://fg-cromwell_fresh/regenie/WORKFLOW_ID/call-sub_step2/**/call-summary/**/*.gz*`  
+`gs://fg-cromwell_fresh/regenie/WORKFLOW_ID/call-sub_step2/**/call-gather/**/*.gz*`
 Plots:  
 `gs://fg-cromwell_fresh/regenie/WORKFLOW_ID/call-sub_step2/**/*.png`  
 Summary files with p < 1e-6 variants including annotation:  

--- a/wdl/gwas/regenie_quantitative.json
+++ b/wdl/gwas/regenie_quantitative.json
@@ -1,0 +1,25 @@
+{
+    "regenie.sub_step1.step1.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.2.4.fixed.gz.mkl",
+    "regenie.sub_step2.docker": "eu.gcr.io/finngen-refinery-dev/regenie:v2.2.4.fixed.gz.mkl",
+
+    "regenie.phenolist": "gs://mkanai-fg/pheno/HEIGHT_WEIGHT_BMI.txt",
+    "regenie.is_binary": false,
+    "regenie.cov_pheno": "gs://r7_data/pheno/R7_COV_PHENO_V2.FID.txt.gz",
+    "regenie.covariates": "SEX_IMPUTED,AGE_AT_DEATH_OR_END_OF_FOLLOWUP,PC{1:10},IS_FINNGEN2_CHIP,BATCH_DS1_BOTNIA_Dgi_norm,BATCH_DS10_FINRISK_Palotie_norm,BATCH_DS11_FINRISK_PredictCVD_COROGENE_Tarto_norm,BATCH_DS12_FINRISK_Summit_norm,BATCH_DS13_FINRISK_Bf_norm,BATCH_DS14_GENERISK_norm,BATCH_DS15_H2000_Broad_norm,BATCH_DS16_H2000_Fimm_norm,BATCH_DS17_H2000_Genmets_norm,BATCH_DS18_MIGRAINE_1_norm,BATCH_DS19_MIGRAINE_2_norm,BATCH_DS2_BOTNIA_T2dgo_norm,BATCH_DS20_SUPER_1_norm,BATCH_DS21_SUPER_2_norm,BATCH_DS22_TWINS_1_norm,BATCH_DS23_TWINS_2_norm,BATCH_DS24_SUPER_3_norm,BATCH_DS25_BOTNIA_Regeneron_norm,BATCH_DS3_COROGENE_Sanger_norm,BATCH_DS4_FINRISK_Corogene_norm,BATCH_DS5_FINRISK_Engage_norm,BATCH_DS6_FINRISK_FR02_Broad_norm,BATCH_DS7_FINRISK_FR12_norm,BATCH_DS8_FINRISK_Finpcga_norm,BATCH_DS9_FINRISK_Mrpred_norm",
+
+    "regenie.sub_step1.step1.grm_bed": "gs://r7_data/grm/R7_GRM_V1_LD_0.1.bed",
+    "regenie.sub_step1.step1.bsize": 1000,
+    "regenie.sub_step1.step1.options": "",
+
+    "regenie.sub_step2.bgenlist": "gs://r7_data/bgen/R7_bgen.txt",
+    "regenie.sub_step2.step2.test": "additive",
+    "regenie.sub_step2.step2.bsize": 400,
+    "regenie.sub_step2.step2.options": "",
+
+    "regenie.sub_step2.gather.docker": "gcr.io/finngen-refinery-dev/saige:0.39.1-fg",
+
+    "regenie.sub_step2.summary.docker": "gcr.io/finngen-refinery-dev/saige:0.39.1-fg-pysam",
+    "regenie.sub_step2.summary.finngen_annotation": "gs://r7_data/annotations/R7_annotated_variants_v0.gz",
+    "regenie.sub_step2.summary.gnomad_annotation": "gs://r4_data_west1/gnomad_functional_variants/fin_enriched_genomes_select_columns.txt.gz",
+    "regenie.sub_step2.summary.pval_thresh": 1e-6
+}

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -11,7 +11,7 @@ task step2 {
     File bgi = bgen + ".bgi"
     File sample = bgen + ".sample"
     File pred
-    File firth_list
+    File? firth_list
     String prefix = sub(basename(pred), "_pred.list", "") + "." + basename(bgen)
     Array[File] loco
     Array[File] nulls
@@ -46,7 +46,7 @@ task step2 {
         --phenoFile ${cov_pheno} \
         --phenoColList ${sep="," phenolist} \
         --pred ${pred} \
-        --use-null-firth ${firth_list} \
+        ${if is_binary then "--use-null-firth ${firth_list}" else ""} \
         --bsize ${bsize} \
         --threads $n_cpu \
         --gz \

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -11,7 +11,7 @@ task step2 {
     File bgi = bgen + ".bgi"
     File sample = bgen + ".sample"
     File pred
-    File? firth_list
+    File firth_list
     String prefix = sub(basename(pred), "_pred.list", "") + "." + basename(bgen)
     Array[File] loco
     Array[File] nulls


### PR DESCRIPTION
Although the `is_binary` option is already implemented, the current workflow throws an error when `is_binary=false`. This PR fixes that error.