### PR TITLE
Remove problematic covariates on the fly

### DIFF
--- a/wdl/gwas/regenie.wdl
+++ b/wdl/gwas/regenie.wdl
@@ -42,7 +42,7 @@ workflow regenie {
             input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates
         }
         call sub.regenie_step2 as sub_step2 {
-            input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=covariates, pred=sub_step1.pred, loco=sub_step1.loco, nulls=sub_step1.nulls, firth_list=sub_step1.firth_list
+            input: phenolist=pheno_chunk, is_binary=is_binary, cov_pheno=cov_pheno, covariates=sub_step1.new_covariates, pred=sub_step1.pred, loco=sub_step1.loco, nulls=sub_step1.nulls, firth_list=sub_step1.firth_list
         }
     }
 

--- a/wdl/gwas/regenie_quantitative.json
+++ b/wdl/gwas/regenie_quantitative.json
@@ -10,6 +10,7 @@
     "regenie.sub_step1.step1.grm_bed": "gs://r7_data/grm/R7_GRM_V1_LD_0.1.bed",
     "regenie.sub_step1.step1.bsize": 1000,
     "regenie.sub_step1.step1.options": "",
+    "regenie.sub_step1.step1.covariate_inclusion_threshold": 10,
 
     "regenie.sub_step2.bgenlist": "gs://r7_data/bgen/R7_bgen.txt",
     "regenie.sub_step2.step2.test": "additive",

--- a/wdl/gwas/regenie_r8.json
+++ b/wdl/gwas/regenie_r8.json
@@ -10,6 +10,7 @@
     "regenie.sub_step1.step1.grm_bed": "gs://r8_data/grm/sisuv4/R8_sisuv4_GRM_V0_LD_0.1.bed",
     "regenie.sub_step1.step1.bsize": 1000,
     "regenie.sub_step1.step1.options": "",
+    "regenie.sub_step1.step1.covariate_inclusion_threshold": 10,
 
     "regenie.sub_step2.bgenlist": "gs://r8_data/bgen/sisuv4/R8_bgen.txt",
     "regenie.sub_step2.step2.test": "additive",

--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -12,7 +12,7 @@ task step1 {
     String options
 
     String docker
-    Int cov_filter_th = 10
+    Int covariate_inclusion_threshold
     command <<<
 
         set -euxo pipefail
@@ -22,7 +22,7 @@ task step1 {
         COVARFILE=${cov_pheno}
         PHENO="${phenolist sep=','}"
         COVARS="${covariates}"
-        THRESHOLD=${cov_filter_th}
+        THRESHOLD=${covariate_inclusion_threshold}
         # Filter binary covariates that don't have enough covariate values in them
         # Inputs: covariate file, comma-separated phenolist, comma-separated covariate list, threshold for excluding a covariate
         # If a covariate is quantitative (=having values different from 0,1,NA), it is masked and will be passed through.

--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -12,13 +12,74 @@ task step1 {
     String options
 
     String docker
-
+    Int cov_filter_th = 10
     command <<<
 
         set -euxo pipefail
 
-        n_cpu=`grep -c ^processor /proc/cpuinfo`
 
+        #filter degenerate covariates, e.g. sex imputed from sex-specific phenotypes
+        COVARFILE=${cov_pheno}
+        PHENO="${phenolist sep=','}"
+        COVARS="${covariates}"
+        THRESHOLD=${cov_filter_th}
+        # Filter binary covariates that don't have enough covariate values in them
+        # Inputs: covariate file, comma-separated phenolist, comma-separated covariate list, threshold for excluding a covariate
+        # If a covariate is quantitative (=having values different from 0,1,NA), it is masked and will be passed through.
+        # If a binary covariate has value NA, it will not be counted towards 0 or 1 for that covariate.
+        # If a covariate does not seem to exist (e.g. PC{1:10}), it will be passed through.
+        # If any of the phenotypes is not NA on that row, that row will be counted. This is in line with the step1 mean-imputation for multiple phenotypes.
+        zcat $COVARFILE |awk -v covariates=$COVARS  -v phenos=$PHENO -v th=$THRESHOLD > new_covars  '
+        BEGIN{FS="\t"}
+        NR == 1 {
+            covlen = split(covariates,covars,",")
+            phlen = split(phenos,phenoarr,",")
+            for (i=1; i<=NF; i++){
+                h[$i] = i
+                mask[$i] = 0
+            }
+        }
+        NR > 1 {
+            #if any of the phenotypes is not NA, then take the row into account
+            process_row=0
+            for (ph in phenoarr){
+                if ($h[phenoarr[ph]] != "NA"){
+                    process_row = 1
+                }
+            }
+            if (process_row == 1){
+                for (co in covars){
+                    if($h[covars[co]] == 0) {
+                        zerovals[covars[co]] +=1
+                    }
+                    else if($h[covars[co]] == 1) {
+                        onevals[covars[co]] +=1
+                    }
+                    else if($h[covars[co]] == "NA"){
+                        #no-op
+                        na=0;
+                    }
+                    else {
+                        #mask this covariate to be included, no matter the counts
+                        #includes both covariate not found in header and quantitative covars
+                        mask[covars[co]] =1
+                    }
+                }
+            }
+
+        }
+        END{
+            SEP=""
+            for (co in covars){
+                if( ( zerovals[covars[co]] > th && onevals[covars[co]] > th ) || mask[covars[co]] == 1 ){
+                    printf("%s%s" ,SEP,covars[co])
+                    SEP=","
+                }
+            }
+        }'
+
+        n_cpu=`grep -c ^processor /proc/cpuinfo`
+        NEWCOVARS=$(cat new_covars)
         # fid needs to be the same as iid in fam
         awk '{$1=$2} 1' ${grm_fam} > tempfam && mv tempfam ${grm_fam}
 
@@ -27,7 +88,7 @@ task step1 {
         ${if is_binary then "--bt" else ""} \
         --bed ${sub(grm_bed, "\\.bed$", "")} \
         --covarFile ${cov_pheno} \
-        --covarColList ${covariates} \
+        --covarColList $NEWCOVARS \
         --phenoFile ${cov_pheno} \
         --phenoColList ${sep="," phenolist} \
         --bsize ${bsize} \
@@ -70,6 +131,7 @@ task step1 {
         File pred = glob("*.pred.list")[0]
         Array[File] nulls = glob("*.firth.gz")
         File firth_list = glob("*.firth.list")[0]
+        String used_covariates = read_string("new_covars")
     }
 
     runtime {
@@ -100,5 +162,6 @@ workflow regenie_step1 {
         Array[File] loco = step1.loco
         File firth_list = step1.firth_list
         Array[File] nulls = step1.nulls
+        String new_covariates = step1.new_covars
     }
 }

--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -75,6 +75,7 @@ task step1 {
                     printf("%s%s" ,SEP,covars[co])
                     SEP=","
                 }
+                printf "Covariate %s zero count: %d one count: %d mask: %d\n",covars[co],zerovals[covars[co]],onevals[covars[co]],mask[covars[co]] >> "/dev/stderr"; 
             }
         }'
 


### PR DESCRIPTION
This PR adds a script in step 1, which does the following:
- For binary covariates, if the covariate has only one variate (e.g. sex imputed being only 1 for a female-specific phenotype), it will be removed from the list of covariates. Quantitative endpoints are passed through. NAs in covariates will not count towards inclusion. Missing endpoints (e.g. PC{1:10} shorthand) will be passed through. For multiple phenotypes, the rows are counted like they would be if the phenotypes' missing values were imputed, i.e. only if all phenotypes have NA, that row will not be counted.
The covariates are passed on to step2, and are included as step1 outputs.

There is currently no logging of e.g. how many covariate 0/1 there were for each covariate, but that can be added if helpful.