### PR TITLE
Skip sex-specific analysis for a sex when there are too little cases

### DIFF
--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -28,17 +28,6 @@ task step2 {
     String DOLLAR="$"
 
     command <<<
-        echo '''BEGIN{print_males ="males";print_females="females";males[0]=0;males[1]=0;females[0]=0;females[1]=0}
-NR==1{ for(i=1;i<=NF;i++) {h[$i]=i}}
-NR>1{
-if($h[sexcol]==0 && $h[phenocol]!="NA"){males[$h[phenocol]] += 1 }
-if($h[sexcol]==1 && $h[phenocol]!="NA"){females[$h[phenocol]] += 1}}
-END{
-if(males[0]<10 ||males[1]<10){print_males = "";print "Skipping male sex-specific analysis: phenotype",phenocol,"had only",males[0] ",", males[1], "male controls/cases." > "/dev/stderr"}
-if(females[0]<10 ||females[1]<10){print_females = "";print "Skipping female sex-specific analysis: phenotype",phenocol,"had only",females[0] ",", females[1], "female controls/cases." > "/dev/stderr"}
-print print_males,print_females
-}
-''' > filter_sex_spec_analysis.awk
         ## continue statement exits with 1.... switch to if statement below in case want to pipefail back
         ##set -euxo pipefail
 
@@ -130,6 +119,27 @@ print print_males,print_females
             # NOTE
             # NOTE figure out whether we can run males and or females sex-specific analysis. In some endpoints, there are too little 
             # NOTE cases (under 10) per sex, which errors out the script.
+
+            # save a mock file for the case where the analysis could not be performed
+            echo -n "ID A1FREQ_CASES A1FREQ_CONTROLS N BETA SE LOG10P" |bgzip > mock_sex_spec.txt.gz
+            echo '''BEGIN{print_males ="males";print_females="females";males[0]=0;males[1]=0;females[0]=0;females[1]=0}
+NR==1{ for(i=1;i<=NF;i++) {h[$i]=i}}
+NR>1{
+if($h[sexcol]==0 && $h[phenocol]!="NA"){males[$h[phenocol]] += 1 }
+if($h[sexcol]==1 && $h[phenocol]!="NA"){females[$h[phenocol]] += 1}}
+END{
+if(males[0]<10 ||males[1]<10){
+print_males = ""
+print "Skipping male sex-specific analysis: phenotype",phenocol,"had only",males[0] ",", males[1], "male controls/cases." > "/dev/stderr"
+cmd = "cp mock_sex_spec.txt.gz " ${prefix}.sex_spec.males_" phenocol ".gz";system(cmd)}
+if(females[0]<10 ||females[1]<10){
+print_females = ""
+print "Skipping female sex-specific analysis: phenotype",phenocol,"had only",females[0] ",", females[1], "female controls/cases." > "/dev/stderr"
+cmd = "cp mock_sex_spec.txt.gz " ${prefix}.sex_spec.females_" phenocol ".gz";system(cmd)}
+}
+print print_males,print_females
+}
+''' > filter_sex_spec_analysis.awk
             sex_analyses=$(zcat ${cov_pheno} | awk -v phenocol=$p -v sexcol=${sex_col_name} -f filter_sex_spec_analysis.awk)
 
             for s in $sex_analyses;

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -131,11 +131,12 @@ END{
 if(males[0]<10 ||males[1]<10){
 print_males = ""
 print "Skipping male sex-specific analysis: phenotype",phenocol,"had only",males[0] ",", males[1], "male controls/cases." > "/dev/stderr"
-cmd = "cp mock_sex_spec.txt.gz " ${prefix}.sex_spec.males_" phenocol ".gz";system(cmd)}
+cmd = sprintf("cp mock_sex_spec.txt.gz ${prefix}.sex_spec.males_%s.gz", phenocol);system(cmd)
+}
 if(females[0]<10 ||females[1]<10){
 print_females = ""
 print "Skipping female sex-specific analysis: phenotype",phenocol,"had only",females[0] ",", females[1], "female controls/cases." > "/dev/stderr"
-cmd = "cp mock_sex_spec.txt.gz " ${prefix}.sex_spec.females_" phenocol ".gz";system(cmd)}
+cmd = sprintf("cp mock_sex_spec.txt.gz ${prefix}.sex_spec.females_%s.gz", phenocol);system(cmd)
 }
 print print_males,print_females
 }


### PR DESCRIPTION
For some rare and very sex-skewed endpoints, it is possible that e.g. male or female cases are too low for regenie to perform sex-specific analysis. In that case, current master fails.
This PR has a check for that, and in case that check fails, that analysis won't be performed, and instead a dummy output file is copied to the sex-specific analysis files' place.