### PR TITLE
trim disk sizes for wdl tasks since they are way oversized

### DIFF
--- a/wdl/gwas/regenie_step1.wdl
+++ b/wdl/gwas/regenie_step1.wdl
@@ -187,7 +187,7 @@ task step1 {
         docker: "${docker}"
         cpu: if length(phenolist) == 1 then 1 else if length(phenolist) <=10 then 2 else 4
         memory: if length(phenolist) == 1 then "12 GB" else "16 GB"
-        disks: "local-disk 200 HDD"
+        disks: "local-disk 40 HDD"
         zones: "europe-west1-b europe-west1-c europe-west1-d"
         preemptible: 2
         noAddress: true

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -318,7 +318,7 @@ task gather {
         docker: "${docker}"
         cpu: 1
         memory: "8 GB"
-        disks: "local-disk 200 HDD"
+        disks: "local-disk 20 HDD"
         zones: "europe-west1-b europe-west1-c europe-west1-d"
         preemptible: 2
         noAddress: true
@@ -453,7 +453,7 @@ task summary{
         docker: "${docker}"
         cpu: 1
         memory: "2 GB"
-        disks: "local-disk 200 HDD"
+        disks: "local-disk 60 HDD"
         zones: "europe-west1-b europe-west1-c europe-west1-d"
         preemptible: 2
     }


### PR DESCRIPTION
A std disk costs 0.04$/GB/month.
Therefore, 200GB disk is between 8/month, or ( divided by 24*31 hrs) 0.01$/hr. Since we use about 6 hrs of compute during step1, that's 2500 endpoints*6*0.01 = 150$/release. It's not much, but it's something : ) 