### PR TITLE
Add checkpointing to regenie wdl

### DIFF
--- a/scripts/check_previous_results.py
+++ b/scripts/check_previous_results.py
@@ -2,9 +2,9 @@ import sys
 import glob
 import argparse
 from enum import Flag,auto
-from typing import Optional
+from typing import Optional, Tuple, List
 # chromosomal range type alias for convenience
-chromRange = tuple[str,int,int]
+chromRange = Tuple[str,int,int]
 class AnalysisState(Flag):
     NOT_STARTED = auto()
     INCOMPLETE = auto()
@@ -29,7 +29,7 @@ prefix= args.prefix
 
 NO_VARIANTS_MIN_VALUE=1000000000
 NO_VARIANTS_MAX_VALUE=-1000000000
-def read_processed_range(files:list[str])->Optional[chromRange]:
+def read_processed_range(files:List[str])->Optional[chromRange]:
     """
     Read in the processed range from files
     Returns an optional tuple of chromosome, first position, last position

--- a/scripts/check_previous_results.py
+++ b/scripts/check_previous_results.py
@@ -1,0 +1,149 @@
+import sys
+import glob
+import argparse
+from enum import Flag,auto
+from typing import Optional
+# chromosomal range type alias for convenience
+chromRange = tuple[str,int,int]
+class AnalysisState(Flag):
+    NOT_STARTED = auto()
+    INCOMPLETE = auto()
+    FINISHED = auto()
+
+class SexSpecState(Flag):
+    NOT_COMPLETE = auto()
+    FINISHED = auto()
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("variant_list")
+parser.add_argument("--analysis-type")
+parser.add_argument("--endpoints")
+parser.add_argument("--prefix")
+args = parser.parse_args()
+variant_file = args.variant_list
+analysis_type = args.analysis_type.lower()
+endpoints = args.endpoints.split(",")
+prefix= args.prefix
+
+
+NO_VARIANTS_MIN_VALUE=1000000000
+NO_VARIANTS_MAX_VALUE=-1000000000
+def read_processed_range(files:list[str])->Optional[chromRange]:
+    """
+    Read in the processed range from files
+    Returns an optional tuple of chromosome, first position, last position
+    Returns a tuple of chromosome, first position, last position
+    """
+    chroms = []
+    pos_mins = []
+    pos_maxs = []
+    for fname in files:
+        chrom = ""
+        pos_min = NO_VARIANTS_MIN_VALUE
+        pos_max = NO_VARIANTS_MAX_VALUE
+        with open(fname,"r") as f:
+            l = f.readline()
+            c = l.strip().split(" ")
+            # if header is malformed, then nothing is processed.
+            if not ( (len(c) == 18 and analysis_type == "true") or (len(c)==14 and analysis_type == "false")):
+                return None
+            for line in f:
+                c = line.strip().split(" ")
+                #if line is malformed, break
+                if not ( (len(c) == 18 and analysis_type == "true") or (len(c)==14 and analysis_type == "false")):
+                    break
+                if chrom == "":
+                    chrom = c[0]
+                pos = int(c[1])
+                pos_min = min(pos,pos_min)
+                pos_max = max(pos,pos_max)
+        pos_mins.append(pos_min)
+        pos_maxs.append(pos_max)
+        chroms.append(chrom)
+    pos_min = min(pos_mins)
+    pos_max = min(pos_maxs)
+    if not all([a == chroms[0] for a in chroms]):
+        #odd, all files don't have same chromosome
+        print("Not all files have same chromosome! This is very odd!",file=sys.stderr)
+        print(f"Processed chroms:{chroms}")
+    if pos_min != NO_VARIANTS_MIN_VALUE and pos_max != NO_VARIANTS_MAX_VALUE:
+        return (chroms[0],pos_min,pos_max)
+    return None
+    
+def get_chunk_range(all_variants_file:str)->chromRange:
+    """
+    Get range still to be processed for files
+    Returns a tuple of chromosome, first position, last position
+    """
+    chrom = ""
+    pos_min = NO_VARIANTS_MIN_VALUE
+    pos_max = NO_VARIANTS_MAX_VALUE
+    with open(all_variants_file,"r") as f:
+        _ = f.readline()
+        for line in f:
+            c = line.strip().split("\t")
+            if chrom == "":
+                chrom = c[2].replace("chr","")
+            pos = int(c[3])
+            pos_min = min(pos,pos_min)
+            pos_max = max(pos,pos_max)
+    return (chrom,pos_min,pos_max) 
+
+complete_files = glob.glob("checkpoint_folder/*.regenie.gz")
+incomplete_files = glob.glob("checkpoint_folder/*.regenie")
+# sex specific
+sex_specific_files = glob.glob("checkpoint_folder/*.sex_spec.gz")
+log = glob.glob(f"checkpoint_folder/{prefix}.log")
+# all endpoints are run, if all endpoints are in complete files (gzipped files), and if there is a log.
+endpoints_run :bool= all([any([f"{a}.regenie" in b for b in complete_files]) for a in endpoints]) and (len(log)==1)
+incomplete_files_for_each_endpoint :bool = all([any([f"{a}.regenie" in b for b in incomplete_files]) for a in endpoints])
+# determine current state
+analysis_state:AnalysisState
+if endpoints_run:
+    analysis_state = AnalysisState.FINISHED
+elif incomplete_files_for_each_endpoint:
+    analysis_state = AnalysisState.INCOMPLETE
+else:
+    analysis_state = AnalysisState.NOT_STARTED
+
+print(f"The state of analysis in checkpoint is {analysis_state}",file=sys.stderr)
+
+if analysis_state == AnalysisState.FINISHED:
+    with open("phenos_done","w") as f:
+        f.write("True\n")
+# if there are incomplete files for each of the endpoints
+elif analysis_state == AnalysisState.INCOMPLETE:
+    # get processed range
+    proc_range = read_processed_range(incomplete_files)
+    if proc_range != None:
+        chunk_range = get_chunk_range(variant_file)
+        remaining_range = (chunk_range[0],proc_range[2],chunk_range[2])
+        with open("remaining_range","w") as f:
+            f.write(f"{remaining_range[0]}:{remaining_range[1]}-{remaining_range[2]}")
+        with open("processed_range","w") as f:
+            f.write(f"{proc_range[0]}:{proc_range[1]}-{proc_range[2]}")
+else:
+    pass
+# sex-specific endpoints
+# I only look at the actual finished files, no male or female files separately. Let that be the MVP.
+# I can also just check whether the file is done in checkpointing folder, and if so, just copy it out from there.
+# That would be done in the actual script.
+
+
+done_sex_spec = [a for a in endpoints if any([f"{a}.sex_spec.gz" in b for b in sex_specific_files])]
+not_done_sex_spec = [a for a in endpoints if a not in done_sex_spec]
+all_sex_spec_done = all([a in done_sex_spec for a in endpoints])
+sex_spec_state:SexSpecState
+if all_sex_spec_done:
+    sex_spec_state = SexSpecState.FINISHED
+else:
+    sex_spec_state = SexSpecState.NOT_COMPLETE
+print(f"The state of sex-specific analysis in checkpoint is {sex_spec_state}",file=sys.stderr)
+if sex_spec_state == SexSpecState.FINISHED:
+    with open("sex_spec_done","w") as f:
+        f.write("True\n")
+elif sex_spec_state == SexSpecState.NOT_COMPLETE:
+    with open("not_done_sex_spec","w",encoding="utf-8") as f:
+        for p in not_done_sex_spec:
+            f.write(f"{p}\n")

--- a/scripts/combine_files.py
+++ b/scripts/combine_files.py
@@ -1,0 +1,47 @@
+import sys
+import glob
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("glob_command")
+parser.add_argument("--output-name")
+parser.add_argument("--endpoints")
+args = parser.parse_args()
+glob_command = args.glob_command
+output_name = args.output_name
+phenos = args.endpoints.split(",")
+
+files = glob.glob(glob_command)
+#do endpoints separately
+for p in phenos:
+    data = []
+    headers = []
+    files_ = [a for a in files if f"{p}.regenie" in a]
+    for fname in files_:
+        with open(fname,"r") as f:
+            headers.append(f.readline().strip().split(" "))
+            for l in f:
+                data.append(l.strip().split(" "))
+    # check headers are the same
+    if not all([a == headers[0] for a in headers]):
+        print("NOT ALL HEADERS SAME!")
+        for i in len(headers):
+            print(files_[i],header[i])
+        sys.exit(1)
+    header = headers[0]
+    # order data by chrom:pos
+    data2 = sorted(data,key=lambda x:(x[0],int(x[1])))
+    #make unique. Only include variants that are not already in variant set.
+    data = []
+    dataset = set()
+    var = lambda x:(x[0],x[1],x[3],x[4])
+    for d in data2:
+        if var(d) in dataset:
+            continue
+        else:
+            dataset.add(var(d))
+            data.append(d)
+    with open(f"{output_name}.{p}","w") as of:
+        of.write(" ".join(header)+"\n")
+        for l in data:
+            of.write(" ".join(l)+"\n")

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -28,160 +28,219 @@ task step2 {
     String DOLLAR="$"
 
     command <<<
-      ## continue statement exits with 1.... switch to if statement below in case want to pipefail back
-        ##set -euxo pipefail
 
-        n_cpu=`grep -c ^processor /proc/cpuinfo`
+    ## create inputs
+    n_cpu=`grep -c ^processor /proc/cpuinfo`
+    # create loco and firth lists
+    paste ${write_lines(phenolist)} ${write_lines(nulls)} > firth_list
+    paste ${write_lines(phenolist)} ${write_lines(loco)} > loco_list
+    ## write scripts into files
 
-        # move loco files to /cromwell_root as pred file paths point there
-        for file in ${sep=" " loco}; do
-            mv $file .
-        done
+# Check status of checkpoint with python script
+cat << "__EOF__" > script.py
+import sys
+import glob
+import argparse
+from enum import Flag,auto
+from typing import Optional
+# chromosomal range type alias for convenience
+chromRange = tuple[str,int,int]
+class AnalysisState(Flag):
+    NOT_STARTED = auto()
+    INCOMPLETE = auto()
+    FINISHED = auto()
 
-        # move null files to /cromwell_root as firth_list file paths point there
-        for file in ${sep=" " nulls}; do
-            mv $file .
-        done
-
-        regenie \
-        --step 2 \
-        ${test_cmd} \
-        ${if is_binary then "--bt --af-cc" else ""} \
-        --bgen ${bgen} \
-        --ref-first \
-        --sample ${sample} \
-        --covarFile ${cov_pheno} \
-        --covarColList ${covariates} \
-        --phenoFile ${cov_pheno} \
-        --phenoColList ${sep="," phenolist} \
-        --pred ${pred} \
-        ${if is_binary then "--use-null-firth ${firth_list}" else ""} \
-        --bsize ${bsize} \
-        --threads $n_cpu \
-        --gz \
-        --out ${prefix} \
-        ${options}
+class SexSpecState(Flag):
+    NOT_COMPLETE = auto()
+    FINISHED = auto()
 
 
-        if [[ "${run_sex_specific}" == "true" ]];
-        then
-          zcat ${cov_pheno} | awk 'NR==1{ for(i=1;i<=NF;i++) {h[$i]=i};
-                                             if(!("${sex_col_name}" in h)) {
-                                                print "Given sex column not found in phenotype file" > "/dev/stderr";
-                                                exit 1;
-                                              }
-                                        }
-                                  NR>1&&$h["${sex_col_name}"]==0{ print $1,$1}' > males
+parser = argparse.ArgumentParser()
+parser.add_argument("variant_list")
+parser.add_argument("--analysis-type")
+parser.add_argument("--endpoints")
+parser.add_argument("--prefix")
+args = parser.parse_args()
+variant_file = args.variant_list
+analysis_type = args.analysis_type.lower()
+endpoints = args.endpoints.split(",")
+prefix= args.prefix
 
-          zcat ${cov_pheno} | awk 'NR==1{  for(i=1;i<=NF;i++) {h[$i]=i };
-                                          if(!("${sex_col_name}" in h))
-                                          {
-                                            print "Given sex column not found in phenotype file" > "/dev/stderr";
-                                            exit 1;
-                                          }
-                                       }
-                                  NR>1&&$h["${sex_col_name}"]==1{ print $1,$1}' > females
 
-          sex_covars=$(echo ${covariates} | sed -e 's/${sex_col_name}//' | sed 's/^,//' | sed -e 's/,$//' | sed 's/,,/,/g')
+NO_VARIANTS_MIN_VALUE=1000000000
+NO_VARIANTS_MAX_VALUE=-1000000000
+def read_processed_range(files:list[str])->Optional[chromRange]:
+    """
+    Read in the processed range from files
+    Returns an optional tuple of chromosome, first position, last position
+    Returns a tuple of chromosome, first position, last position
+    """
+    chroms = []
+    pos_mins = []
+    pos_maxs = []
+    for fname in files:
+        chrom = ""
+        pos_min = NO_VARIANTS_MIN_VALUE
+        pos_max = NO_VARIANTS_MAX_VALUE
+        with open(fname,"r") as f:
+            l = f.readline()
+            c = l.strip().split(" ")
+            # if header is malformed, then nothing is processed.
+            if not ( (len(c) == 18 and analysis_type == "true") or (len(c)==14 and analysis_type == "false")):
+                return None
+            for line in f:
+                c = line.strip().split(" ")
+                #if line is malformed, break
+                if not ( (len(c) == 18 and analysis_type == "true") or (len(c)==14 and analysis_type == "false")):
+                    break
+                if chrom == "":
+                    chrom = c[0]
+                pos = int(c[1])
+                pos_min = min(pos,pos_min)
+                pos_max = max(pos,pos_max)
+        pos_mins.append(pos_min)
+        pos_maxs.append(pos_max)
+        chroms.append(chrom)
+    pos_min = min(pos_mins)
+    pos_max = min(pos_maxs)
+    if not all([a == chroms[0] for a in chroms]):
+        #odd, all files don't have same chromosome
+        print("Not all files have same chromosome! This is very odd!",file=sys.stderr)
+        print(f"Processed chroms:{chroms}")
+    if pos_min != NO_VARIANTS_MIN_VALUE and pos_max != NO_VARIANTS_MAX_VALUE:
+        return (chroms[0],pos_min,pos_max)
+    return None
+    
+def get_chunk_range(all_variants_file:str)->chromRange:
+    """
+    Get range still to be processed for files
+    Returns a tuple of chromosome, first position, last position
+    """
+    chrom = ""
+    pos_min = NO_VARIANTS_MIN_VALUE
+    pos_max = NO_VARIANTS_MAX_VALUE
+    with open(all_variants_file,"r") as f:
+        _ = f.readline()
+        for line in f:
+            c = line.strip().split("\t")
+            if chrom == "":
+                chrom = c[2].replace("chr","")
+            pos = int(c[3])
+            pos_min = min(pos,pos_min)
+            pos_max = max(pos,pos_max)
+    return (chrom,pos_min,pos_max) 
 
-          if [[ $sex_covars == ${covariates} ]];
-          then
-            echo "Warning! No sex covariate detected in used covariates."
-          fi
+complete_files = glob.glob("checkpoint_folder/*.regenie.gz")
+incomplete_files = glob.glob("checkpoint_folder/*.regenie")
+# sex specific
+sex_specific_files = glob.glob("checkpoint_folder/*.sex_spec.gz")
+log = glob.glob(f"checkpoint_folder/{prefix}.log")
+# all endpoints are run, if all endpoints are in complete files (gzipped files), and if there is a log.
+endpoints_run :bool= all([any([f"{a}.regenie" in b for b in complete_files]) for a in endpoints]) and (len(log)==1)
+incomplete_files_for_each_endpoint :bool = all([any([f"{a}.regenie" in b for b in incomplete_files]) for a in endpoints])
+# determine current state
+analysis_state:AnalysisState
+if endpoints_run:
+    analysis_state = AnalysisState.FINISHED
+elif incomplete_files_for_each_endpoint:
+    analysis_state = AnalysisState.INCOMPLETE
+else:
+    analysis_state = AnalysisState.NOT_STARTED
 
-          for p in ${sep=" " phenolist}; do
+print(f"The state of analysis in checkpoint is {analysis_state}",file=sys.stderr)
 
-            if [[ "${is_binary}" == "true" ]];
-            then
-                N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in females {print $1}' females <(zcat ${cov_pheno}) | wc -l)
-                N_cases_males=$(awk -v pheno=$p 'FNR==NR { males[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in males {print $1}' males <(zcat ${cov_pheno}) | wc -l)
-            else 
-                N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]!="NA" && $1 in females {print $1}' females <(zcat ${cov_pheno}) | wc -l)
-                N_cases_males=$(awk -v pheno=$p 'FNR==NR { males[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]!="NA" && $1 in males {print $1}' males <(zcat ${cov_pheno}) | wc -l)
-            fi 
+if analysis_state == AnalysisState.FINISHED:
+    with open("phenos_done","w") as f:
+        f.write("True\n")
+# if there are incomplete files for each of the endpoints
+elif analysis_state == AnalysisState.INCOMPLETE:
+    # get processed range
+    proc_range = read_processed_range(incomplete_files)
+    if proc_range != None:
+        chunk_range = get_chunk_range(variant_file)
+        remaining_range = (chunk_range[0],proc_range[2],chunk_range[2])
+        with open("remaining_range","w") as f:
+            f.write(f"{remaining_range[0]}:{remaining_range[1]}-{remaining_range[2]}")
+        with open("processed_range","w") as f:
+            f.write(f"{proc_range[0]}:{proc_range[1]}-{proc_range[2]}")
+else:
+    pass
+# sex-specific endpoints
+# I only look at the actual finished files, no male or female files separately. Let that be the MVP.
+# I can also just check whether the file is done in checkpointing folder, and if so, just copy it out from there.
+# That would be done in the actual script.
 
-            echo "Female cases: "$N_cases_females
-            echo "Male cases: "$N_cases_males
 
-            if [[ $N_cases_females -lt 10 ]] || [[ $N_cases_males -lt 10 ]];
-            then
-              echo "Less than 10 cases in a sex. Skipping testing of sex specific effects."
-              touch ${prefix}"NOT_DONE.sex_spec.gz"
-              continue
-            fi
+done_sex_spec = [a for a in endpoints if any([f"{a}.sex_spec.gz" in b for b in sex_specific_files])]
+not_done_sex_spec = [a for a in endpoints if a not in done_sex_spec]
+all_sex_spec_done = all([a in done_sex_spec for a in endpoints])
+sex_spec_state:SexSpecState
+if all_sex_spec_done:
+    sex_spec_state = SexSpecState.FINISHED
+else:
+    sex_spec_state = SexSpecState.NOT_COMPLETE
+print(f"The state of sex-specific analysis in checkpoint is {sex_spec_state}",file=sys.stderr)
+if sex_spec_state == SexSpecState.FINISHED:
+    with open("sex_spec_done","w") as f:
+        f.write("True\n")
+elif sex_spec_state == SexSpecState.NOT_COMPLETE:
+    with open("not_done_sex_spec","w",encoding="utf-8") as f:
+        for p in not_done_sex_spec:
+            f.write(f"{p}\n")
+__EOF__
 
-            base=${prefix}"_"$p".regenie.gz"
+# combine outputs from possibly multiple preempted runs
+cat << "__EOF__" > combine_outputs.py
+import sys
+import glob
+import argparse
 
-            zcat $base | awk 'NR==1{ for(i=1;i<=NF;i++) { h[$i]=i };
-                                     if(!("ID" in h )||!("LOG10P" in h))
-                                     {
-                                       print "ID and LOG10P columns expected in association file" >"/dev/stderr"; exit 1}
-                                     }
-                             NR>1&&$h["LOG10P"]>${sex_specific_logpval} { print $h["ID"]} ' > $p".sex_variants"
+parser = argparse.ArgumentParser()
+parser.add_argument("glob_command")
+parser.add_argument("--output-name")
+parser.add_argument("--endpoints")
+args = parser.parse_args()
+glob_command = args.glob_command
+output_name = args.output_name
+phenos = args.endpoints.split(",")
 
-            nvars=$(cat $p".sex_variants"| wc -l  )
+files = glob.glob(glob_command)
+#do endpoints separately
+for p in phenos:
+    data = []
+    headers = []
+    files_ = [a for a in files if f"{p}.regenie" in a]
+    for fname in files_:
+        with open(fname,"r") as f:
+            headers.append(f.readline().strip().split(" "))
+            for l in f:
+                data.append(l.strip().split(" "))
+    # check headers are the same
+    if not all([a == headers[0] for a in headers]):
+        print("NOT ALL HEADERS SAME!")
+        for i in len(headers):
+            print(files_[i],header[i])
+        sys.exit(1)
+    header = headers[0]
+    # order data by chrom:pos
+    data2 = sorted(data,key=lambda x:(x[0],int(x[1])))
+    #make unique. Only include variants that are not already in variant set.
+    data = []
+    dataset = set()
+    var = lambda x:(x[0],x[1],x[3],x[4])
+    for d in data2:
+        if var(d) in dataset:
+            continue
+        else:
+            dataset.add(var(d))
+            data.append(d)
+    with open(f"{output_name}.{p}","w") as of:
+        of.write(" ".join(header)+"\n")
+        for l in data:
+            of.write(" ".join(l)+"\n")
+__EOF__
 
-            echo "$nvars variants will be tested for sex specific effects"
-
-            if [[ $nvars -lt 1 ]];
-            then
-              ## NOTE
-              ## NOTE: Echoing annoyingly the expected header here so that in gather the header can be taken from the first shard.
-              ## NOTE This must match whats written from python below
-            
-                if [[ "${is_binary}" == "true" ]];
-                then
-                     echo -n "CHROM GENPOS ID ALLELE0 ALLELE1 A1FREQ A1FREQ_CASES A1FREQ_CONTROLS INFO N TEST BETA SE CHISQ LOG10P"\
-                        " EXTRA males_ID males_A1FREQ_CASES males_A1FREQ_CONTROLS males_N males_BETA males_SE males_LOG10P"\
-                        " females_ID females_A1FREQ_CASES females_A1FREQ_CONTROLS females_N females_BETA females_SE females_LOG10P"\
-                        " diff_beta p_diff" | bgzip > ${prefix}"."$p".sex_spec.gz"
-                    continue
-                else 
-
-                     echo -n "CHROM GENPOS ID ALLELE0 ALLELE1 A1FREQ INFO N TEST BETA SE CHISQ LOG10P"\
-                        " EXTRA males_ID males_N males_BETA males_SE males_LOG10P"\
-                        " females_ID females_N females_BETA females_SE females_LOG10P"\
-                        " diff_beta p_diff" | bgzip > ${prefix}"."$p".sex_spec.gz"
-                    continue
-                fi 
-            fi
-
-            for s in males females;
-            do
-              echo "running $s analysis"
-              echo "$(wc -l $s) individuals in file"
-              head $s
-
-              regenie \
-              --step 2 \
-              ${test_cmd} \
-              ${if is_binary then "--bt --af-cc" else ""} \
-              --bgen ${bgen} \
-              --ref-first \
-              --sample ${sample} \
-              --keep $s  \
-              --extract $p".sex_variants" \
-              --covarFile ${cov_pheno} \
-              --covarColList $sex_covars \
-              --phenoFile ${cov_pheno} \
-              --phenoColList $p \
-              --pred ${pred} \
-              --bsize ${bsize} \
-              --threads $n_cpu \
-              --gz \
-              --out ${prefix}".sex_spec."$s \
-              ${options}
-            done
-
-            echo "all files"
-            ls *
-
-            for f in $(ls *".sex_spec."*.regenie.gz ); do
-              to=${DOLLAR}{f/%.regenie.gz/.gz}
-              mv $f $to
-              echo "file" $to
-            done
-
+# write sex spec modifying script
 echo '''import pandas as pd
 import gzip
 import sys
@@ -232,13 +291,226 @@ else:
 combs.to_csv(prefix+"."+pheno+".sex_spec.gz", compression="gzip", sep=" ", index=False)
 
 ''' > source.py
-          python3 source.py $p ${prefix} ${prefix}"_"$p".regenie.gz"
-          done
-        else
-          ## sex specific analyses disabled but create the file so gather step is straightforward to implement
-          touch ${prefix}"NOT_DONE.sex_spec.gz"
+
+# write checkpointing script
+cat << "__EOF__" > checkpoint.sh
+#!/bin/bash
+touch placeholder.regenie.placeholder placeholder.log
+while [ 1 -eq 1 ];do
+    tar -cf checkpoint_new.tar *.regenie* *.log *.sex_spec.gz
+    cp checkpoint.tar checkpoint_old.tar
+    mv checkpoint_new.tar checkpoint.tar
+    sleep 60
+done
+__EOF__
+chmod +x checkpoint.sh
+
+## check current progress
+bgenix -g ${bgen} -list |grep -Ev "^#" > variants.list
+
+mkdir checkpoint_folder
+if test -f checkpoint.tar;then
+    if tar -xf checkpoint.tar -C checkpoint_folder/; then
+        python3 script.py variants.list "${is_binary}" "${sep="," phenolist}" "${prefix}"
+    fi
+fi
+# start checkpointing script
+./checkpoint.sh &
+CHECKPOINT_PID=$!
+## run regenie
+
+# check if checkpoint file contains regenie outputs
+if test -f phenos_done; then
+    #copy files to here
+    cp checkpoint_folder/*.regenie.gz ./
+    cp checkpoint_folder/${prefix}.log ./
+else 
+    # test if we have processed some range
+    if test -f remaining_range; then
+        #move all non-complete male regenie outputs to have the range that they
+        PROCESSED_RANGE=$(cat processed_range)
+        for f in checkpoint_folder/*.regenie;do
+            cp $f $f.$PROCESSED_RANGE
+        done
+        #copy all files with any range from checkpoint folder to main folder
+        # this will fix the problem with one or more ranges missing when  
+        cp checkpoint_folder/*.regenie.* ./
+        cat checkpoint_folder/*.log* > ./${prefix}.log.$PROCESSED_RANGE
+        REMAINING_RANGE=$(cat remaining_range)
+        #we have, use the calculated remaining range 
+        RANGE_OPTION="--range "$REMAINING_RANGE
+        echo "Remaining range "$REMAINING_RANGE
+    fi
+    regenie \
+    --step 2 \
+    ${test_cmd} \
+    ${if is_binary then "--bt --af-cc" else ""} \
+    --bgen ${bgen} \
+    --ref-first \
+    --sample ${sample} \
+    --covarFile ${cov_pheno} \
+    --covarColList ${covariates} \
+    --phenoFile ${cov_pheno} \
+    --phenoColList ${sep="," phenolist} \
+    --pred loco_list \
+    ${if is_binary then "--use-null-firth firth_list" else ""} \
+    --bsize ${bsize} \
+    --threads $n_cpu \
+    --out ${prefix} \
+    $RANGE_OPTION \
+    ${options}
+    python3 combine_outputs.py "${prefix}*.regenie*" temp.regenie "${sep="," phenolist}"
+    #kill checkpointing for a moment. This is to prevent a situation where the partially compressed files are checkpointed, confusing the checkpointing script.
+    kill $CHECKPOINT_PID 
+    for p in ${sep=" " phenolist};do
+        cat temp.regenie.$p |gzip >  ${prefix}"_"$p".regenie.gz"
+    done
+    #compress
+    tar -cf checkpoint.tar *.regenie.gz ${prefix}.log*
+    #restart checkpointing
+    ./checkpoint.sh &
+    CHECKPOINT_PID=$!
+fi
+
+
+## run sex-specific analysis
+
+if [[ "${run_sex_specific}" == "true" ]];
+then
+    if test -f sex_spec_done; then
+        #copy things 
+        cp checkpoint_folder/*.sex_spec.gz ./
+    else
+        zcat ${cov_pheno} | awk 'NR==1{ for(i=1;i<=NF;i++) {h[$i]=i};
+                                            if(!("${sex_col_name}" in h)) {
+                                            print "Given sex column not found in phenotype file" > "/dev/stderr";
+                                            exit 1;
+                                            }
+                                    }
+                                NR>1&&$h["${sex_col_name}"]==0{ print $1,$1}' > males
+
+        zcat ${cov_pheno} | awk 'NR==1{  for(i=1;i<=NF;i++) {h[$i]=i };
+                                        if(!("${sex_col_name}" in h))
+                                        {
+                                        print "Given sex column not found in phenotype file" > "/dev/stderr";
+                                        exit 1;
+                                        }
+                                    }
+                                NR>1&&$h["${sex_col_name}"]==1{ print $1,$1}' > females
+
+        sex_covars=$(echo ${covariates} | sed -e 's/${sex_col_name}//' | sed 's/^,//' | sed -e 's/,$//' | sed 's/,,/,/g')
+
+        if [[ $sex_covars == ${covariates} ]];
+        then
+        echo "Warning! No sex covariate detected in used covariates."
+        fi
+        # checkpointing: Sex-spec phenos not done are in not_done_sex_spec,
+        cat not_done_sex_spec | while read p || [[ -n $line ]];
+        do
+        #for p in ${sep=" " phenolist}; do
+
+        if [[ "${is_binary}" == "true" ]];
+        then
+            N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in females {print $1}' females <(zcat ${cov_pheno}) | wc -l)
+            N_cases_males=$(awk -v pheno=$p 'FNR==NR { males[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in males {print $1}' males <(zcat ${cov_pheno}) | wc -l)
+        else 
+            N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]!="NA" && $1 in females {print $1}' females <(zcat ${cov_pheno}) | wc -l)
+            N_cases_males=$(awk -v pheno=$p 'FNR==NR { males[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]!="NA" && $1 in males {print $1}' males <(zcat ${cov_pheno}) | wc -l)
+        fi 
+
+        echo "Female cases: "$N_cases_females
+        echo "Male cases: "$N_cases_males
+
+        if [[ $N_cases_females -lt 10 ]] || [[ $N_cases_males -lt 10 ]];
+        then
+            echo "Less than 10 cases in a sex. Skipping testing of sex specific effects."
+            touch ${prefix}"NOT_DONE.sex_spec.gz"
+            continue
         fi
 
+        base=${prefix}"_"$p".regenie.gz"
+
+        zcat $base | awk 'NR==1{ for(i=1;i<=NF;i++) { h[$i]=i };
+                                    if(!("ID" in h )||!("LOG10P" in h))
+                                    {
+                                    print "ID and LOG10P columns expected in association file" >"/dev/stderr"; exit 1}
+                                    }
+                            NR>1&&$h["LOG10P"]>${sex_specific_logpval} { print $h["ID"]} ' > $p".sex_variants"
+
+        nvars=$(cat $p".sex_variants"| wc -l  )
+
+        echo "$nvars variants will be tested for sex specific effects"
+
+        if [[ $nvars -lt 1 ]];
+        then
+            ## NOTE
+            ## NOTE: Echoing annoyingly the expected header here so that in gather the header can be taken from the first shard.
+            ## NOTE This must match whats written from python below
+        
+            if [[ "${is_binary}" == "true" ]];
+            then
+                    echo -n "CHROM GENPOS ID ALLELE0 ALLELE1 A1FREQ A1FREQ_CASES A1FREQ_CONTROLS INFO N TEST BETA SE CHISQ LOG10P"\
+                    " EXTRA males_ID males_A1FREQ_CASES males_A1FREQ_CONTROLS males_N males_BETA males_SE males_LOG10P"\
+                    " females_ID females_A1FREQ_CASES females_A1FREQ_CONTROLS females_N females_BETA females_SE females_LOG10P"\
+                    " diff_beta p_diff" | bgzip > ${prefix}"."$p".sex_spec.gz"
+                continue
+            else 
+
+                    echo -n "CHROM GENPOS ID ALLELE0 ALLELE1 A1FREQ INFO N TEST BETA SE CHISQ LOG10P"\
+                    " EXTRA males_ID males_N males_BETA males_SE males_LOG10P"\
+                    " females_ID females_N females_BETA females_SE females_LOG10P"\
+                    " diff_beta p_diff" | bgzip > ${prefix}"."$p".sex_spec.gz"
+                continue
+            fi 
+        fi
+
+        for s in males females;
+        do
+            echo "running $s analysis"
+            echo "$(wc -l $s) individuals in file"
+            head $s
+
+            regenie \
+            --step 2 \
+            ${test_cmd} \
+            ${if is_binary then "--bt --af-cc" else ""} \
+            --bgen ${bgen} \
+            --ref-first \
+            --sample ${sample} \
+            --keep $s  \
+            --extract $p".sex_variants" \
+            --covarFile ${cov_pheno} \
+            --covarColList $sex_covars \
+            --phenoFile ${cov_pheno} \
+            --phenoColList $p \
+            --pred ${pred} \
+            --bsize ${bsize} \
+            --threads $n_cpu \
+            --gz \
+            --out ${prefix}".sex_spec."$s \
+            ${options}
+        done
+
+        echo "all files"
+        ls *
+
+        for f in $(ls *".sex_spec."*.regenie.gz ); do
+            to=${DOLLAR}{f/%.regenie.gz/.gz}
+            mv $f $to
+            echo "file" $to
+        done
+
+
+        python3 source.py $p ${prefix} ${prefix}"_"$p".regenie.gz"
+        # Checkpointing: recreate the checkpoint
+        tar -cf checkpoint.tar *.regenie.gz ${prefix}.log* *.sex_spec.gz
+        done
+    fi
+else
+    ## sex specific analyses disabled but create the file so gather step is straightforward to implement
+    touch ${prefix}"NOT_DONE.sex_spec.gz"
+fi
+kill $CHECKPOINT_PID
     >>>
 
     output {
@@ -250,11 +522,12 @@ combs.to_csv(prefix+"."+pheno+".sex_spec.gz", compression="gzip", sep=" ", index
     runtime {
         docker: "${docker}"
         cpu: if length(phenolist) == 1 then 1 else if length(phenolist) <=4 then 2 else if length(phenolist) <= 10 then 4 else if length(phenolist) < 16 then 8 else 16
-        memory: if length(phenolist) <= 2 then "4 GB" else "6 GB"
+        memory:  "6 GB"
         disks: "local-disk " + (ceil(size(bgen, "G")) + 5) + " HDD"
         zones: "europe-west1-b europe-west1-c europe-west1-d"
         preemptible: 2
         noAddress: true
+        checkpointFile: "checkpoint.tar"
     }
 }
 

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -424,7 +424,7 @@ then
 
         if [[ "${is_binary}" == "true" ]];
         then
-            N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in females {print $1}' females <(cat minified_phenofile}) | wc -l)
+            N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in females {print $1}' females <(cat minified_phenofile) | wc -l)
             N_cases_males=$(awk -v pheno=$p 'FNR==NR { males[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]==1 && $1 in males {print $1}' males <(cat minified_phenofile) | wc -l)
         else 
             N_cases_females=$(awk -v pheno=$p 'FNR==NR { females[$1]; next } FNR==1{ for(i=1;i<=NF;i++) {h[$i]=i} }; NR>1 && $h[pheno]!="NA" && $1 in females {print $1}' females <(cat minified_phenofile) | wc -l)

--- a/wdl/gwas/regenie_sub.wdl
+++ b/wdl/gwas/regenie_sub.wdl
@@ -300,7 +300,7 @@ while [ 1 -eq 1 ];do
     tar -cf checkpoint_new.tar *.regenie* *.log *.sex_spec.gz
     cp checkpoint.tar checkpoint_old.tar
     mv checkpoint_new.tar checkpoint.tar
-    sleep 60
+    sleep 120
 done
 __EOF__
 chmod +x checkpoint.sh


### PR DESCRIPTION
Checkpointing refers to saving the state/some output files of a worker, so that in the case of preemption, the work of the next attempt can be lessened. See https://cromwell.readthedocs.io/en/latest/optimizations/CheckpointFiles/# for more information.

This PR implements checkpointing to the step2 task in regenie_sub.wdl. This is by far the most compute-intensive task in the regenie workflow, and preemption often increases the cost of the workflow.
What the checkpointing should do, is allow us to use some of the computation done even in preempted machines. In principle, we should lose at most 12 minutes of computations in case of preemption (currently cromwell is set up to checkpoint every 10 minutes, and the checkpoint creation script in worker runs every 2 minutes). This makes the subsequent tries' workload smaller, which will in turn make preemption less likely.
Main analysis is checkpointed on a continuous basis, always saving the currently processed variants. Regenie should output them continuously, and gzip compression is disabled, so checkpoints will have a tsv that has some portion of the chunk variants.
Sex-specific analysis, if it is run, is checkpointed on a finished sex-specific file at a time. Therefore, this is mainly useful if processing multiple endpoints at a time (which is not encouraged, regenie has convergence issues even with well-overlapping endpoints). If there's only one endpoint, sex-specific analysis is checkpointed at the end of the workflow, making it irrelevant.

Overview of code:
check_previous_results.py (embedded in the wdl task) is responsible for figuring out the state of the task in the beginning of execution. It will figure out if progress was made in an earlier attempt, and if so, determine the range of variants that will be processed. The ranges to be processed include the ends of the last region, so no variants should be dropped, but duplicate results for a variant might be produced in the regenie analysis.
combine_files.py (embedded in the wdl task) is responsible for combining the processed summstats into one coherent summstat. It will only take one result per variant. If there are multiple summstats per variant (=it was included in one attempt's results and the next attempt's results as well), only one will be taken. They should all be identical.

The workflow organization is roughly:
- Write environment variables
- Write scripts into files
- determine current status and processing ranges
- start checkpointing
- run main analysis
- combine outputs, compress
- if sex-spec analysis, run that

NOTE: this change requires bgenix in the docker image. Compiling and adding bgentools into docker image is the preferred way. 
